### PR TITLE
Update base url to discord.com

### DIFF
--- a/flask_discord/configs.py
+++ b/flask_discord/configs.py
@@ -1,4 +1,4 @@
-DISCORD_API_BASE_URL = "https://discordapp.com/api"
+DISCORD_API_BASE_URL = "https://discord.com/api"
 
 DISCORD_AUTHORIZATION_BASE_URL = DISCORD_API_BASE_URL + "/oauth2/authorize"
 DISCORD_TOKEN_URL = DISCORD_API_BASE_URL + "/oauth2/token"


### PR DESCRIPTION
I know the deadline is 7th October, but better to fix this sooner than later, so bunch of users doesn't complain about their OAuth2 implementation is broken.